### PR TITLE
INT-476 added method to call diagnostic endpoints after using the script

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "teamserverUrl": "https://<YOUR ENVIRONMENT>.contrastsecurity.com/Contrast/api/ng/",
     "apiKey": "",
     "authorizationHeader": "",
-    "orgId": ""
+    "orgId": "",
+    "allowProductUsageAnalytics": true
 }

--- a/contrast_api.py
+++ b/contrast_api.py
@@ -124,3 +124,16 @@ class ContrastTeamServer:
             org_id + '/rules/' + rule_name, data, api_key)
 
         return response
+
+    def send_usage_event(self, org_id: str, is_reset: bool, api_key: str):
+        usage_mode_endpoint = 'undo' if is_reset else 'setup'
+
+        values = {
+            "type": usage_mode_endpoint
+        }
+
+        data = json.dumps(values).encode("utf-8")
+
+        response = self.post_api_request(org_id + '/integrations/diagnostics/scw', data)
+
+        return response

--- a/contrast_scw.py
+++ b/contrast_scw.py
@@ -13,6 +13,10 @@ org_id = config['orgId']
 
 contrast = contrast_instance_from_json(config)
 
+is_reset = sys.argv and len(sys.argv) > 1 and sys.argv[1] == 'reset'
+
+allow_product_usage_analytics = config.get('allowProductUsageAnalytics', False)
+
 
 def get_scw_base_url(cwe):
     return 'https://integration-api.securecodewarrior.com/api/v1/trial?Id=contrast&MappingList=cwe&MappingKey=' + cwe
@@ -40,7 +44,7 @@ org_key = contrast.org_api_key(org_id)['api_key']
 
 # Loop through all the Assess rules
 for rule in contrast.list_org_policy(org_id, org_key):
-    if sys.argv and len(sys.argv) > 1 and sys.argv[1] == 'reset':
+    if is_reset:
         #The reset argument has been passed, erase all rule references.
         res = contrast.update_rule_references(
             org_id, rule['name'], [], org_key)
@@ -135,3 +139,7 @@ for rule in contrast.list_org_policy(org_id, org_key):
 
             if res['success'] == True:
                 print(rule['title'] + ' updated successfully')
+                
+
+if allow_product_usage_analytics:
+    contrast.send_usage_event(org_id, is_reset, org_key)


### PR DESCRIPTION
# Purpose
Adds a method to call diagnostic event endpoints when the script is run

# Notes
1. The method is controlled by the `allowProductUsageAnalytics` field in the config.json
1. The diagnostics endpoints rely on the product usage analytics setting set by the organization admin, so even if allowProductUsageAnalytics is set to true, the endpoint might still ignore the event.