### PR TITLE
Remove Beta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Secure Code Warrior Integration (beta)
+# Secure Code Warrior Integration
 
 This script is used to provide links from within Contrast to relevant training videos and exercises within the Secure Code Warrior platform. The links appear in the "How to Fix" area of a vulnerability within the Contrast TeamServer UI and IDE plugins.
 


### PR DESCRIPTION
SCW reached out asking if we can remove the beta tag from this and our KB article. I can't find a lot of issues and the integration's been live for two years so I believe we're in good shape.